### PR TITLE
Apply basic optimizations

### DIFF
--- a/align_test.go
+++ b/align_test.go
@@ -20,3 +20,12 @@ func TestAlign(t *testing.T) {
 	}
 
 }
+
+func BenchmarkAlign(b *testing.B) {
+	seq1 := "GGAATTAATCCAGGTAATGGACCCCAAGAT"
+	seq2 := "GCCAGGATTCCCAGATATGGCCAAGGTTCC"
+
+	for i := 0; i < b.N; i++ {
+		Align(seq1, seq2, 1, -1, -1)
+	}
+}

--- a/align_test.go
+++ b/align_test.go
@@ -5,18 +5,18 @@
 package nwalgo
 
 import (
-    "testing"
+	"testing"
 )
 
 func TestAlign(t *testing.T) {
-    seqs := [][]string{
-        []string{"CGAGAGA","GAGAGA", "CGAGAGA", "-GAGAGA"} }
+	seqs := [][]string{
+		[]string{"CGAGAGA", "GAGAGA", "CGAGAGA", "-GAGAGA"}}
 
-    for _,a := range seqs {
-        aln1, aln2, _ := Align(a[0], a[1], 1, -1, -1)
-        if aln1 != a[2] || aln2 != a[3] {
-            t.Errorf("Align(%s, %s)\n***GOT***\n%s\n%s\n***WANT***\n%s\n%s", a[0],a[1],aln1,aln2,a[2],a[3])
-        }
-    }
+	for _, a := range seqs {
+		aln1, aln2, _ := Align(a[0], a[1], 1, -1, -1)
+		if aln1 != a[2] || aln2 != a[3] {
+			t.Errorf("Align(%s, %s)\n***GOT***\n%s\n%s\n***WANT***\n%s\n%s", a[0], a[1], aln1, aln2, a[2], a[3])
+		}
+	}
 
 }

--- a/nw.go
+++ b/nw.go
@@ -5,87 +5,87 @@
 package nwalgo
 
 import (
-    "fmt"
+	"fmt"
 )
 
-var UP    = 1
-var LEFT  = 2
-var NW    = 3
-var NONE  = 4
+var UP = 1
+var LEFT = 2
+var NW = 3
+var NONE = 4
 
-func Align(a ,b string, match, mismatch, gap int) (string, string, int) {
+func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 
-    alen := len(a)+1
-    blen := len(b)+1
+	alen := len(a) + 1
+	blen := len(b) + 1
 
-    f := make([][]int, alen)
-    pointer := make([][]int, alen)
-    for i := range f {
-        f[i] = make([]int, blen)
-        pointer[i] = make([]int, blen)
-    }
+	f := make([][]int, alen)
+	pointer := make([][]int, alen)
+	for i := range f {
+		f[i] = make([]int, blen)
+		pointer[i] = make([]int, blen)
+	}
 
-    for i:= 1; i < alen; i++ {
-        f[i][0] = gap*i
-        pointer[i][0] = UP
-    }
-    for j:= 1; j < blen; j++ {
-        f[0][j] = gap*j
-        pointer[0][j] = LEFT
-    }
+	for i := 1; i < alen; i++ {
+		f[i][0] = gap * i
+		pointer[i][0] = UP
+	}
+	for j := 1; j < blen; j++ {
+		f[0][j] = gap * j
+		pointer[0][j] = LEFT
+	}
 
-    pointer[0][0] = NONE
-    for i:= 1; i < alen; i++ {
-        for j:= 1; j < blen; j++ {
-            match_mismatch := mismatch
-            if a[i-1] == b[j-1] {
-                match_mismatch = match
-            }
+	pointer[0][0] = NONE
+	for i := 1; i < alen; i++ {
+		for j := 1; j < blen; j++ {
+			match_mismatch := mismatch
+			if a[i-1] == b[j-1] {
+				match_mismatch = match
+			}
 
-            max := f[i-1][j-1] + match_mismatch
-            hgap := f[i-1][j] + gap
-            vgap := f[i][j-1] + gap
-            if hgap > max {
-                 max = hgap
-            }
-            if vgap > max {
-                 max = vgap
-            }
+			max := f[i-1][j-1] + match_mismatch
+			hgap := f[i-1][j] + gap
+			vgap := f[i][j-1] + gap
+			if hgap > max {
+				max = hgap
+			}
+			if vgap > max {
+				max = vgap
+			}
 
-            p := NW;
-            if max == hgap  {
-                p = UP
-            } else if max == vgap {
-                p = LEFT
-            }
+			p := NW
+			if max == hgap {
+				p = UP
+			} else if max == vgap {
+				p = LEFT
+			}
 
-            pointer[i][j] = p
-            f[i][j] = max
-        }
-    }
+			pointer[i][j] = p
+			f[i][j] = max
+		}
+	}
 
-    i := alen-1
-    j := blen-1
-    aln1 := ""
-    aln2 := ""
-    score := f[i][j]
+	i := alen - 1
+	j := blen - 1
+	aln1 := ""
+	aln2 := ""
+	score := f[i][j]
 
-    for p := pointer[i][j]; p != NONE; p = pointer[i][j] {
-        if p == NW {
-            aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
-            aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
-            i--
-            j--
-        } else if p == UP  {
-            aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
-            aln2 = fmt.Sprintf("%s%s", "-", aln2)
-            i--
-        } else if p == LEFT  {
-            aln1 = fmt.Sprintf("%s%s", "-", aln1)
-            aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
-            j--
-        }
-    }
+	for p := pointer[i][j]; p != NONE; p = pointer[i][j] {
+		if p == NW {
+			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
+			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
+			i--
+			j--
+		} else if p == UP {
+			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
+			aln2 = fmt.Sprintf("%s%s", "-", aln2)
+			i--
+		} else if p == LEFT {
+			aln1 = fmt.Sprintf("%s%s", "-", aln1)
+			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
+			j--
+		}
+	}
 
-    return aln1,aln2,score
+	return aln1, aln2, score
 }

--- a/nw.go
+++ b/nw.go
@@ -4,10 +4,6 @@
 
 package nwalgo
 
-import (
-	"fmt"
-)
-
 const (
 	Up   = 1
 	Left = 2
@@ -15,10 +11,18 @@ const (
 	None = 4
 )
 
-func Align(a, b string, match, mismatch, gap int) (string, string, int) {
+func Align(a, b string, match, mismatch, gap int) (alignA, alignB string, score int) {
 
 	alen := len(a) + 1
 	blen := len(b) + 1
+
+	maxLen := alen
+	if maxLen < blen {
+		maxLen = blen
+	}
+
+	aBytes := make([]byte, 0, maxLen)
+	bBytes := make([]byte, 0, maxLen)
 
 	f := make([][]int, alen)
 	pointer := make([][]int, alen)
@@ -68,26 +72,25 @@ func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 
 	i := alen - 1
 	j := blen - 1
-	aln1 := ""
-	aln2 := ""
-	score := f[i][j]
+
+	score = f[i][j]
 
 	for p := pointer[i][j]; p != None; p = pointer[i][j] {
 		if p == NW {
-			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
-			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
+			aBytes = append([]byte(a[i-1:i]), aBytes...)
+			bBytes = append([]byte(b[j-1:j]), bBytes...)
 			i--
 			j--
 		} else if p == Up {
-			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
-			aln2 = fmt.Sprintf("%s%s", "-", aln2)
+			aBytes = append([]byte(a[i-1:i]), aBytes...)
+			bBytes = append([]byte{'-'}, bBytes...)
 			i--
 		} else if p == Left {
-			aln1 = fmt.Sprintf("%s%s", "-", aln1)
-			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
+			aBytes = append([]byte{'-'}, aBytes...)
+			bBytes = append([]byte(b[j-1:j]), bBytes...)
 			j--
 		}
 	}
 
-	return aln1, aln2, score
+	return string(aBytes), string(bBytes), score
 }

--- a/nw.go
+++ b/nw.go
@@ -4,11 +4,11 @@
 
 package nwalgo
 
-const (
-	Up   = 1
-	Left = 2
-	NW   = 3
-	None = 4
+var (
+	Up   byte = 1
+	Left byte = 2
+	NW   byte = 3
+	None byte = 4
 )
 
 func idx(i, j, bLen int) int {
@@ -29,7 +29,7 @@ func Align(a, b string, match, mismatch, gap int) (alignA, alignB string, score 
 	bBytes := make([]byte, 0, maxLen)
 
 	f := make([]int, aLen*bLen)
-	pointer := make([]int, aLen*bLen)
+	pointer := make([]byte, aLen*bLen)
 
 	for i := 1; i < aLen; i++ {
 		f[idx(i, 0, bLen)] = gap * i

--- a/nw.go
+++ b/nw.go
@@ -11,46 +11,48 @@ const (
 	None = 4
 )
 
+func idx(i, j, bLen int) int {
+	return (i * bLen) + j
+}
+
 func Align(a, b string, match, mismatch, gap int) (alignA, alignB string, score int) {
 
-	alen := len(a) + 1
-	blen := len(b) + 1
+	aLen := len(a) + 1
+	bLen := len(b) + 1
 
-	maxLen := alen
-	if maxLen < blen {
-		maxLen = blen
+	maxLen := aLen
+	if maxLen < bLen {
+		maxLen = bLen
 	}
 
 	aBytes := make([]byte, 0, maxLen)
 	bBytes := make([]byte, 0, maxLen)
 
-	f := make([][]int, alen)
-	pointer := make([][]int, alen)
-	for i := range f {
-		f[i] = make([]int, blen)
-		pointer[i] = make([]int, blen)
+	f := make([]int, aLen*bLen)
+	pointer := make([]int, aLen*bLen)
+
+	for i := 1; i < aLen; i++ {
+		f[idx(i, 0, bLen)] = gap * i
+		pointer[idx(i, 0, bLen)] = Up
+	}
+	for j := 1; j < bLen; j++ {
+		f[idx(0, j, bLen)] = gap * j
+		pointer[idx(0, j, bLen)] = Left
 	}
 
-	for i := 1; i < alen; i++ {
-		f[i][0] = gap * i
-		pointer[i][0] = Up
-	}
-	for j := 1; j < blen; j++ {
-		f[0][j] = gap * j
-		pointer[0][j] = Left
-	}
+	pointer[0] = None
 
-	pointer[0][0] = None
-	for i := 1; i < alen; i++ {
-		for j := 1; j < blen; j++ {
-			match_mismatch := mismatch
+	for i := 1; i < aLen; i++ {
+		for j := 1; j < bLen; j++ {
+			matchMismatch := mismatch
 			if a[i-1] == b[j-1] {
-				match_mismatch = match
+				matchMismatch = match
 			}
 
-			max := f[i-1][j-1] + match_mismatch
-			hgap := f[i-1][j] + gap
-			vgap := f[i][j-1] + gap
+			max := f[idx(i-1, j-1, bLen)] + matchMismatch
+			hgap := f[idx(i-1, j, bLen)] + gap
+			vgap := f[idx(i, j-1, bLen)] + gap
+
 			if hgap > max {
 				max = hgap
 			}
@@ -65,17 +67,17 @@ func Align(a, b string, match, mismatch, gap int) (alignA, alignB string, score 
 				p = Left
 			}
 
-			pointer[i][j] = p
-			f[i][j] = max
+			pointer[idx(i, j, bLen)] = p
+			f[idx(i, j, bLen)] = max
 		}
 	}
 
-	i := alen - 1
-	j := blen - 1
+	i := aLen - 1
+	j := bLen - 1
 
-	score = f[i][j]
+	score = f[idx(i, j, bLen)]
 
-	for p := pointer[i][j]; p != None; p = pointer[i][j] {
+	for p := pointer[idx(i, j, bLen)]; p != None; p = pointer[idx(i, j, bLen)] {
 		if p == NW {
 			aBytes = append(aBytes, a[i-1])
 			bBytes = append(bBytes, b[j-1])

--- a/nw.go
+++ b/nw.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 )
 
-var UP = 1
-var LEFT = 2
-var NW = 3
-var NONE = 4
+const (
+	Up   = 1
+	Left = 2
+	NW   = 3
+	None = 4
+)
 
 func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 
@@ -27,14 +29,14 @@ func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 
 	for i := 1; i < alen; i++ {
 		f[i][0] = gap * i
-		pointer[i][0] = UP
+		pointer[i][0] = Up
 	}
 	for j := 1; j < blen; j++ {
 		f[0][j] = gap * j
-		pointer[0][j] = LEFT
+		pointer[0][j] = Left
 	}
 
-	pointer[0][0] = NONE
+	pointer[0][0] = None
 	for i := 1; i < alen; i++ {
 		for j := 1; j < blen; j++ {
 			match_mismatch := mismatch
@@ -54,9 +56,9 @@ func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 
 			p := NW
 			if max == hgap {
-				p = UP
+				p = Up
 			} else if max == vgap {
-				p = LEFT
+				p = Left
 			}
 
 			pointer[i][j] = p
@@ -70,17 +72,17 @@ func Align(a, b string, match, mismatch, gap int) (string, string, int) {
 	aln2 := ""
 	score := f[i][j]
 
-	for p := pointer[i][j]; p != NONE; p = pointer[i][j] {
+	for p := pointer[i][j]; p != None; p = pointer[i][j] {
 		if p == NW {
 			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
 			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
 			i--
 			j--
-		} else if p == UP {
+		} else if p == Up {
 			aln1 = fmt.Sprintf("%c%s", a[i-1], aln1)
 			aln2 = fmt.Sprintf("%s%s", "-", aln2)
 			i--
-		} else if p == LEFT {
+		} else if p == Left {
 			aln1 = fmt.Sprintf("%s%s", "-", aln1)
 			aln2 = fmt.Sprintf("%c%s", b[j-1], aln2)
 			j--

--- a/nw.go
+++ b/nw.go
@@ -77,20 +77,30 @@ func Align(a, b string, match, mismatch, gap int) (alignA, alignB string, score 
 
 	for p := pointer[i][j]; p != None; p = pointer[i][j] {
 		if p == NW {
-			aBytes = append([]byte(a[i-1:i]), aBytes...)
-			bBytes = append([]byte(b[j-1:j]), bBytes...)
+			aBytes = append(aBytes, a[i-1])
+			bBytes = append(bBytes, b[j-1])
 			i--
 			j--
 		} else if p == Up {
-			aBytes = append([]byte(a[i-1:i]), aBytes...)
-			bBytes = append([]byte{'-'}, bBytes...)
+			aBytes = append(aBytes, a[i-1])
+			bBytes = append(bBytes, '-')
 			i--
 		} else if p == Left {
-			aBytes = append([]byte{'-'}, aBytes...)
-			bBytes = append([]byte(b[j-1:j]), bBytes...)
+			aBytes = append(aBytes, '-')
+			bBytes = append(bBytes, b[j-1])
 			j--
 		}
 	}
 
+	reverse(aBytes)
+	reverse(bBytes)
+
 	return string(aBytes), string(bBytes), score
+}
+
+func reverse(a []byte) {
+	for i := 0; i < len(a)/2; i++ {
+		j := len(a) - 1 - i
+		a[i], a[j] = a[j], a[i]
+	}
 }


### PR DESCRIPTION
Hi Andrew, I found your package on godoc.org.

I've applied some optimizations that improve the efficiency of the Align function.
- fmt is no longer imported.
- bytes are used to build the result instead of strings.
- slice-of-slice is not used; instead, a single slice with an index function is used.
- building the results is done in reverse order, and then a reversal is done in-place afterwards.

With the benchmark I wrote, this results in a nice 3.5x speedup, and a very large reduction in allocations, from 268 allocs/op to 8 allocs/op. The amount of memory used is also reduced, mostly owing to using []byte instead of []int for the 'pointer' variable.

I've formatted the files I touched with gofmt, so the diff isn't all that great to look at. I left the commits un-squashed, so you can get a better idea of what is actually changing in the PR.

Cheers...
